### PR TITLE
use platform_family for debian and rhel in default filter settings

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -16,7 +16,7 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'rhel'"
+  -  "entity.system.platform_family == 'rhel'"
 - platform: "debian"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_debian_linux_amd64.tar.gz"
@@ -24,4 +24,4 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'debian'"
+  -  "entity.system.platform_family == 'debian'"


### PR DESCRIPTION
Fix overly tight filter settings so runtime can be used on ubuntu and centos without editting of asset config.