### PR TITLE
exclude glibc provided libraries

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -3,6 +3,9 @@ FROM centos:7
 ARG RUBY_VERSION=2.4.4
 ARG ASSET_VERSION=local_build
 
+ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
+
+
 RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl
 
 RUN curl -L https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz -o ruby-install-0.7.0.tar.gz && \
@@ -12,7 +15,7 @@ RUN curl -L https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz -o 
   ruby-install ruby ${RUBY_VERSION} -- --enable-load-relative --disable-install-doc && \
   PATH=$PATH:/opt/rubies/ruby-${RUBY_VERSION}/bin/ && gem install --no-ri --no-rdoc ffi
 
-RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | grep -v "libc.so" | grep -v "vdso.so.1" | awk '{print $3}'| sort -u ) && \
+RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/rubies/ruby-${RUBY_VERSION}/lib/; fi; done
 
 RUN mkdir /assets/ && \

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -2,6 +2,7 @@ FROM centos:6
 
 ARG RUBY_VERSION=2.4.4
 ARG ASSET_VERSION=local_build
+ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
 
 RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl
 
@@ -12,7 +13,7 @@ RUN curl -L https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz -o 
   ruby-install ruby ${RUBY_VERSION} -- --enable-load-relative --disable-install-doc && \
   PATH=$PATH:/opt/rubies/ruby-${RUBY_VERSION}/bin/ && gem install --no-ri --no-rdoc ffi
 
-RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | grep -v "libc.so" | grep -v "vdso.so.1" | awk '{print $3}'| sort -u ) && \
+RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/rubies/ruby-${RUBY_VERSION}/lib/; fi; done
 
 RUN mkdir /assets/ && \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -2,6 +2,8 @@ FROM centos:7
 
 ARG RUBY_VERSION=2.4.4
 ARG ASSET_VERSION=local_build
+ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
+
 
 RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl
 
@@ -12,7 +14,7 @@ RUN curl -L https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz -o 
   ruby-install ruby ${RUBY_VERSION} -- --enable-load-relative --disable-install-doc && \
   PATH=$PATH:/opt/rubies/ruby-${RUBY_VERSION}/bin/ && gem install --no-ri --no-rdoc ffi 
 
-RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | grep -v "libc.so" | grep -v "vdso.so.1" | awk '{print $3}'| sort -u ) && \
+RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/rubies/ruby-${RUBY_VERSION}/lib/; fi; done
 
 RUN mkdir /assets/ && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -2,6 +2,7 @@ FROM debian:stretch
 
 ARG RUBY_VERSION=2.4.4
 ARG ASSET_VERSION=local_build
+ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
 
 RUN apt-get update && apt-get install -y build-essential curl
 
@@ -12,7 +13,7 @@ RUN curl -L https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz -o 
   ruby-install ruby ${RUBY_VERSION} -- --enable-load-relative --disable-install-doc && \
   PATH=$PATH:/opt/rubies/ruby-${RUBY_VERSION}/bin/ && gem install --no-ri --no-rdoc ffi 
 
-RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | grep -v "libc.so" | grep -v "vdso.so.1" | awk '{print $3}'| sort -u ) && \
+RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/rubies/ruby-${RUBY_VERSION}/lib/; fi; done
 
 RUN mkdir /assets/ && \

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -2,6 +2,7 @@ FROM debian:stretch
 
 ARG RUBY_VERSION=2.4.4
 ARG ASSET_VERSION=local_build
+ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
 
 RUN apt-get update && apt-get install -y build-essential curl
 
@@ -12,7 +13,7 @@ RUN curl -L https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz -o 
   ruby-install ruby ${RUBY_VERSION} -- --enable-load-relative --disable-install-doc && \
   PATH=$PATH:/opt/rubies/ruby-${RUBY_VERSION}/bin/ && gem install --no-ri --no-rdoc ffi 
 
-RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | grep -v "libc.so" | grep -v "vdso.so.1" | awk '{print $3}'| sort -u ) && \
+RUN LIBS=$(find /opt/rubies/ruby-${RUBY_VERSION} -type f -executable -exec ldd {} 2>/dev/null \;|  grep "=>" | egrep -v ${GREP_EXCLUDE} | awk '{print $3}'| sort -u ) && \
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /opt/rubies/ruby-${RUBY_VERSION}/lib/; fi; done
 
 RUN mkdir /assets/ && \


### PR DESCRIPTION
Removing the glibc linraries from centos* debian* builds.

glibc libraries are treated as pre-existing part of the base OS.

This appears to make the ruby-runtime assets a bit more cross-platform.
 

